### PR TITLE
Issue 57 - No barcode found dialog

### DIFF
--- a/www/modules/search/controllers/SearchCtrl.js
+++ b/www/modules/search/controllers/SearchCtrl.js
@@ -137,7 +137,12 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
                                     .cancel(kLocalizeFilter('search.fuzzyMatch.cancel'))
                             )
                                 .then(function () {
+                                    //Yes button click handler
                                     self.searchByKeywords(products[0].name);
+                                },
+                                function() {
+                                    //No button click handler
+                                    self.state = self.states.SEARCH;
                                 });
                         }
                         else {
@@ -215,6 +220,7 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
 
     function processResults(results) {
         results = (results && results.results) || [];
+        self.state = results.length ? self.states.RESULTS : self.states.SEARCH;
         if (results.length === 1) {
             $location.search({});
             $location.replace();
@@ -224,7 +230,6 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
             return;
         }
         self.recalls = results;
-        self.state = self.recalls.length ? self.states.RESULTS : self.states.SEARCH;
     }
 
     function processClassification(results) {

--- a/www/modules/search/locales/en/translation.json
+++ b/www/modules/search/locales/en/translation.json
@@ -26,7 +26,7 @@
         },
         "fuzzyMatch": {
             "title": "UPC Not Found",
-            "content": "__upc__ was not found in the recall list, would you like to search on related recalls for \"__keywords__\"?",
+            "content": "__upc__ was not found in the recall list. Would you like to search on related recalls for \"__keywords__\"?",
             "ok": "Yes, Please!",
             "cancel": "No Thanks"
         }


### PR DESCRIPTION
This update sets the Search screen's state from 'searching' to 'search' when the user clicks the No Thanks button on the No Barcode Found dialog.
