### PR TITLE
Issue 56 - Bar and Pie chart redraw updates

### DIFF
--- a/www/modules/search/controllers/SearchCtrl.js
+++ b/www/modules/search/controllers/SearchCtrl.js
@@ -368,6 +368,7 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
         });
 
         //Update the Recall History chart's main data source.
+        self.recallHistoryData = null;
         self.recallHistoryData = tempRecallHistoryData;
     }
 

--- a/www/modules/search/controllers/SearchCtrl.js
+++ b/www/modules/search/controllers/SearchCtrl.js
@@ -29,7 +29,10 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
 
     var self = this,
         path = $location.path(),
-        keywords, barcode;
+        keywords, barcode,
+        tempRecallHistoryData = [],
+        recallHistoryExpectedCheckInPoints = 4,
+        recallHistoryCheckInPoints = 0;
 
     /**
      * @private
@@ -62,31 +65,6 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
      * @type {array}
      */
     self.recallHistoryData = [];
-
-    /**
-     * A list of recall history results used to populate the final
-     * recallHistoryData array. This array will be used when
-     * making the different api calls to populate the recall history
-     * so the chart doesn't update each time a request is handled.
-     * @name search.controllers.SearchCtrl#tempRecallHistoryData
-     * @propertyOf search.controllers.SearchCtrl
-     * @type {array}
-     */
-    self.tempRecallHistoryData = [];
-
-    /**
-     * The number of api calls expected to be made to populate
-     * the Recall History chart.
-     * @type {number}
-     */
-    self.recallHistoryExpectedCheckInPoints = 5;
-
-    /**
-     * The number of api calls that have been made, of the expected
-     * number, to populate the Recall History chart.
-     * @type {number}
-     */
-    self.recallHistoryCheckInPoints = 0;
 
     /**
      * The list of recall results counted by classification
@@ -247,15 +225,15 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
             thisYear = new Date().getFullYear();
 
         //Reset the number of request that have been handled.
-        self.recallHistoryCheckInPoints = 0;
+        recallHistoryCheckInPoints = 0;
 
         //Establish the base chart data and classification colors.
-        self.tempRecallHistoryData = [{key: 'Class I', color: '#FE0000', values: []},
+        tempRecallHistoryData = [{key: 'Class I', color: '#FE0000', values: []},
             {key: 'Class II', color: '#F47429', values: []},
             {key: 'Class III', color: '#FEF200', values: []}];
 
         //Get history for the last 5 years, including this year. We'll build the list of years and then make the requests.
-        for(var y = thisYear - 4; y <= thisYear; y++) {
+        for(var y = thisYear - 3; y <= thisYear; y++) {
             years.push(y);
         }
 
@@ -310,7 +288,7 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
         });
 
         //Apply the classification group counts.
-        angular.forEach(self.tempRecallHistoryData, function(recallClass) {
+        angular.forEach(tempRecallHistoryData, function(recallClass) {
             switch(recallClass.key) {
                 case 'Class I':
                     recallClass.values.push({x: year, y: class1Count ? class1Count : 0});
@@ -333,7 +311,7 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
      * @param year
      */
     function processRecallHistorySearchError(year) {
-        angular.forEach(self.tempRecallHistoryData, function(recallClass) {
+        angular.forEach(tempRecallHistoryData, function(recallClass) {
             switch(recallClass.key) {
                 case 'Class I':
                     recallClass.values.push({x: year, y: 0});
@@ -357,9 +335,9 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
      * on to our finalize method to update the chart's data source.
      */
     function recallHistorySearchCheckIn() {
-        self.recallHistoryCheckInPoints++;
+        recallHistoryCheckInPoints++;
 
-        if(self.recallHistoryCheckInPoints === self.recallHistoryExpectedCheckInPoints) {
+        if(recallHistoryCheckInPoints === recallHistoryExpectedCheckInPoints) {
             finalizeRecallHistorySearch();
         }
     }
@@ -385,12 +363,12 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
      */
     function finalizeRecallHistorySearch() {
         //Sort the value arrays for each classification entry so years are displayed in the correct order.
-        angular.forEach(self.tempRecallHistoryData, function(recallClass) {
+        angular.forEach(tempRecallHistoryData, function(recallClass) {
             recallClass.values.sort(recallHistorySort);
         });
 
         //Update the Recall History chart's main data source.
-        self.recallHistoryData = self.tempRecallHistoryData;
+        self.recallHistoryData = tempRecallHistoryData;
     }
 
     var search = {};

--- a/www/modules/search/directives/ClassificationDistribution.html
+++ b/www/modules/search/directives/ClassificationDistribution.html
@@ -1,1 +1,3 @@
 <svg></svg>
+<md-divider></md-divider>
+<p i18n="search.classDistribution.chartDescription"></p>

--- a/www/modules/search/directives/ClassificationDistribution.js
+++ b/www/modules/search/directives/ClassificationDistribution.js
@@ -25,8 +25,25 @@ main.directive('classificationDistribution', function () {
         link: function ($scope, $elem, $attr, controllers) {// jshint ignore:line
             var svg = d3.select($elem.find('svg')[0]),
                 win = angular.element(window),
-                chart, legendSeries;
+                chart, legendSeries, chartUpdateDelay;
 
+            /**
+             * Change handler for the chart's data, which calls for
+             * a chart update after a short delay. The delay is in
+             * place to group multiple data updates made around the
+             * same time.
+             */
+            function chartDataChanged() {
+                clearTimeout(chartUpdateDelay);
+                chartUpdateDelay = setTimeout(function() {
+                    chartUpdateDelay = null;
+                    updateData();
+                }, 250);
+            }
+
+            /**
+             * Update the chart based on the current set of data.
+             */
             function updateData() {
                 if (chart && $scope.counts) {
                     var class1Data, class2Data, class3Data, compiledCounts;
@@ -55,7 +72,7 @@ main.directive('classificationDistribution', function () {
                     chart.color(['#FE0000', '#F47429', '#FEF200']);
 
                     svg.datum(compiledCounts)
-                        .transition().duration(500)
+                        .transition().duration(400)
                         .call(chart);
 
                     //Draw a rectangle behind each legend item to provide additional click area.
@@ -81,6 +98,9 @@ main.directive('classificationDistribution', function () {
                 }
             }
 
+            /**
+             * Requests a chart redraw.
+             */
             function resizeChart() {
                 if (chart && chart.update) {
                     chart.update();
@@ -96,14 +116,12 @@ main.directive('classificationDistribution', function () {
                     .showLegend(true)
                     .margin({left: 0, right: 0, top: 0, bottom: 0});
 
-                updateData();
-
                 return chart;
             });
 
             resizeChart();
 
-            $scope.$watch('counts', updateData);
+            $scope.$watch('counts', chartDataChanged);
 
             $elem.addClass('search classification-distribution');
             win.on('resize', resizeChart);

--- a/www/modules/search/directives/ClassificationDistribution.js
+++ b/www/modules/search/directives/ClassificationDistribution.js
@@ -74,14 +74,14 @@ main.directive('classificationDistribution', function () {
                                 });
                         }
                     });
+
+                    setTimeout(function() {
+                        resizeChart();
+                    }, 100);
                 }
             }
 
             function resizeChart() {
-                svg
-                    .style('width', Math.max(300, $elem.height()))
-                    .style('height', Math.max(300, $elem.height()));
-
                 if (chart && chart.update) {
                     chart.update();
                 }
@@ -93,7 +93,8 @@ main.directive('classificationDistribution', function () {
                     .x(function(d) { return d.term; })
                     .y(function(d) { return d.count; })
                     .showLabels(false)
-                    .showLegend(true);
+                    .showLegend(true)
+                    .margin({left: 0, right: 0, top: 0, bottom: 0});
 
                 updateData();
 

--- a/www/modules/search/directives/ClassificationDistribution.scss
+++ b/www/modules/search/directives/ClassificationDistribution.scss
@@ -1,5 +1,11 @@
 .search.classification-distribution {
-    display: block;
-    min-height: 300px;
-    min-width: 300px;
+    p {
+        padding: 0;
+    }
+
+    svg {
+        min-width: 270px;
+        width: 100%;
+        height: 300px;
+    }
 }

--- a/www/modules/search/directives/RecallHistory.html
+++ b/www/modules/search/directives/RecallHistory.html
@@ -1,1 +1,3 @@
 <svg></svg>
+<md-divider></md-divider>
+<p i18n="search.recallHistory.chartDescription"></p>

--- a/www/modules/search/directives/RecallHistory.js
+++ b/www/modules/search/directives/RecallHistory.js
@@ -24,12 +24,29 @@ main.directive('recallHistory', function () {
         link: function ($scope, $elem, $attr, controllers) {// jshint ignore:line
             var svg = d3.select($elem.find('svg')[0]),
                 win = angular.element(window),
-                chart, legendSeries;
+                chart, legendSeries, chartUpdateDelay;
 
+            /**
+             * Change handler for the chart's data, which calls for
+             * a chart update after a short delay. The delay is in
+             * place to group multiple data updates made around the
+             * same time.
+             */
+            function chartDataChanged() {
+                clearTimeout(chartUpdateDelay);
+                chartUpdateDelay = setTimeout(function() {
+                    chartUpdateDelay = null;
+                    updateData();
+                }, 250);
+            }
+
+            /**
+             * Update the chart based on the current set of data.
+             */
             function updateData() {
                 if (chart && $scope.recallHistoryData) {
                     svg.datum($scope.recallHistoryData)
-                        .transition().duration(500)
+                        .transition().duration(400)
                         .call(chart);
 
                     //Draw a rectangle behind each legend item to provide additional click area.
@@ -60,6 +77,9 @@ main.directive('recallHistory', function () {
                 }
             }
 
+            /**
+             * Requests a chart redraw.
+             */
             function resizeChart() {
                 if (chart && chart.update) {
                     chart.update();
@@ -75,20 +95,17 @@ main.directive('recallHistory', function () {
                         .stacked(true)
                         .showControls(false)
                         .groupSpacing(0.1)
-                        .margin({left: 0, right: 0, top: 0, bottom: 30})
-                    ;
+                        .margin({left: 0, right: 0, top: 0, bottom: 30});
 
                 chart.xAxis
                     .tickFormat(d3.format('f'));
-
-                updateData();
 
                 return chart;
             });
 
             resizeChart();
 
-            $scope.$watch('recallHistoryData', updateData, true);
+            $scope.$watch('recallHistoryData', chartDataChanged);
 
             $elem.addClass('search recall-history');
             win.on('resize', resizeChart);

--- a/www/modules/search/directives/RecallHistory.js
+++ b/www/modules/search/directives/RecallHistory.js
@@ -52,6 +52,11 @@ main.directive('recallHistory', function () {
                             }
                         });
                     }
+
+                    setTimeout(function() {
+                        resizeChart();
+                    }, 100);
+
                 }
             }
 
@@ -70,7 +75,7 @@ main.directive('recallHistory', function () {
                         .stacked(true)
                         .showControls(false)
                         .groupSpacing(0.1)
-                        .margin({left: 0, right: 0, top: 0, bottom: 25})
+                        .margin({left: 0, right: 0, top: 0, bottom: 30})
                     ;
 
                 chart.xAxis

--- a/www/modules/search/directives/RecallHistory.scss
+++ b/www/modules/search/directives/RecallHistory.scss
@@ -1,6 +1,11 @@
 .search.recall-history {
+    p {
+        padding: 0;
+    }
+
     svg {
-        min-width: 240px;
-        min-height: 300px;
+        min-width: 270px;
+        width: 100%;
+        height: 300px;
     }
 }

--- a/www/modules/search/locales/en/translation.json
+++ b/www/modules/search/locales/en/translation.json
@@ -20,9 +20,13 @@
         "recallHistTab": "Trends",
         "classDistribution": {
             "title": "Classification Distribution",
+            "chartDescription": "This pie chart displays active recalls returned in the search results by class.",
             "class1Title": "Class I",
             "class2Title": "Class II",
             "class3Title": "Class III"
+        },
+        "recallHistory": {
+            "chartDescription": "This stacked bar chart displays all recalls for the past 4 years by class."
         },
         "fuzzyMatch": {
             "title": "UPC Not Found",

--- a/www/modules/search/views/Index.html
+++ b/www/modules/search/views/Index.html
@@ -142,7 +142,6 @@
                     <input ng-model="searchForm.keywords" type="search" required autocomplete="off">
                 </md-input-container>
                 <md-button type="submit" class="md-raised md-primary" ng-disabled="keywordSearch.$invalid">
-                    <md-icon>search</md-icon>
                     <span i18n="search.searchKeywords"></span>
                 </md-button>
             </form>
@@ -155,7 +154,6 @@
                     <input ng-model="searchForm.barcode" type="search" required autocomplete="off">
                 </md-input-container>
                 <md-button type="submit" class="md-raised md-primary" ng-disabled="barcodeSearch.$invalid">
-                    <md-icon>search</md-icon>
                     <span i18n="search.searchBarcode"></span>
                 </md-button>
             </form>

--- a/www/modules/search/views/Index.html
+++ b/www/modules/search/views/Index.html
@@ -14,7 +14,7 @@
 
     <div flex layout="column" class="result" ng-show="search.state === search.states.RESULTS" layout-gt-sm="row">
         <md-tabs flex class="search-page-content md-primary"
-                 md-stretch-tabs="auto" md-swipe-content="true" md-dynamic-height="false" md-no-disconnect="false"
+                 md-stretch-tabs="auto" md-swipe-content="true" md-dynamic-height="false" md-no-disconnect="true"
                  md-selected-gt-sm="0">
             <md-tab>
                 <md-tab-label>

--- a/www/modules/search/views/Index.scss
+++ b/www/modules/search/views/Index.scss
@@ -39,8 +39,4 @@ $break-small: 600px;
         height: 0px; // Setting this makes sure the content shows scroll
         max-width: 960px;
     }
-    .chart {
-        padding-left: 0;
-        padding-right: 0;
-    }
 }


### PR DESCRIPTION
This PR includes updates for both the pie and bar charts. I added a debounce piece to both that prevents the charts' updateData functions from being called multiple times when their data sets are updated in close succession. 

I also set the Search screen's tab bar md-no-disconnect to true so the tabs' scopes aren't disconnected. I think this may have been leading to some of our update problems. 
