### PR TITLE
Fixes issues #60 and #63 - Removing the shortcut to recall result when 1 result

### DIFF
--- a/www/modules/search/controllers/SearchCtrl.js
+++ b/www/modules/search/controllers/SearchCtrl.js
@@ -215,14 +215,6 @@ main.controller('SearchCtrl', function (/**ng.$rootScope.Scope*/ $scope, $timeou
 
     function processResults(results) {
         results = (results && results.results) || [];
-        if (results.length === 1) {
-            $location.search({});
-            $location.replace();
-            $timeout(function () {
-                $location.path('/recall/' + results[0]['@id']);// jshint ignore:line
-            });
-            return;
-        }
         self.recalls = results;
         self.state = self.recalls.length ? self.states.RESULTS : self.states.SEARCH;
     }


### PR DESCRIPTION
Reasons:
- FDA service can't handle multiple requests in short period of time. Charts are accessing the api multiple times. There are occasions where the recall page shows empty because of this. By applying this we make sure the recall is always accessing the api once in an interval.
- Creates consistency for multiple / single routing.
